### PR TITLE
Accessibility Feedback

### DIFF
--- a/maplibre-control-zoomhome.css
+++ b/maplibre-control-zoomhome.css
@@ -4,9 +4,9 @@
     cursor: pointer;
 }
 
-.maplibre-control-zoomhome button {
-    background-image: url(./home.svg);
-    background-repeat: no-repeat;
-    background-size: 45px 45px;
-    background-position: -7px -7px;
+.maplibre-control-zoomhome button img {
+  width: 45px;
+  position: relative;
+  top: -7px;
+  left: -7px;
 }

--- a/maplibre-control-zoomhome.css
+++ b/maplibre-control-zoomhome.css
@@ -10,3 +10,9 @@
   top: -7px;
   left: -7px;
 }
+
+.maplibre-control-zoomhome button:focus {
+  outline: 2px solid black;
+  border-radius: 3px;
+  box-shadow: none !important;
+}

--- a/maplibre-control-zoomhome.js
+++ b/maplibre-control-zoomhome.js
@@ -19,7 +19,12 @@ class MapLibreControlZoomHome {
         const button = document.createElement('button');
         button.type = 'button';
         button.title = this.options.tooltipText;
-        button.setAttribute('aria-label', this.options.tooltipText);
+
+        const icon = document.createElement('img');
+        icon.setAttribute('src', './home.svg');
+        icon.setAttribute('alt', this.options.tooltipText);
+
+        button.appendChild(icon);
 
         button.addEventListener('click', () => {
             this.resetMapView();


### PR DESCRIPTION
## Review
### Buttons
- [X] The button is marked up as `<button>`.
- [X] The button text describes its purpose sufficiently
- [X] The button has a contrast of 3:1 with the background (or outline).

### Interaction
- [X] The interactive element has a focus indicator on :focus.
    - [X] WCAG 2.1 requires there is an indicator.
    - [X] Sufficient: Using the default user agent focus indicator.
    - [ ] ⛔️ **Recommended: The indicator has at least 3:1 contrast between focused and unfocused state.** → _Addressed in PR_
    - [ ] ⛔️ **Recommended: The indicator has at least 3:1 contrast against the background.** → _Addressed in PR_
    - [ ] ⛔️ **Recommended: The indicator is at least 2px in thickness.** → _Addressed in PR_

## Changed
- Added a darker and thicker focus outline. Again, feel free to update it, as long as it matches 3:1 requirements.
- Changed the `aria-label` on the button with a background image to an image label with alt text. Auto-translate in the browser is better supported with `alt` than `aria-label`, so it's suggested to avoid `aria-label` where possible.
